### PR TITLE
fix link to phoenix website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-A curated list of amazingly awesome [Phoenix](www.phoenixframework.org) resources and projects. Inspired by the various [Awesome](https://github.com/sindresorhus/awesome) lists.
+A curated list of amazingly awesome [Phoenix](http://www.phoenixframework.org) resources and projects. Inspired by the various [Awesome](https://github.com/sindresorhus/awesome) lists.
 
 ## Community
 ### Mailing Lists


### PR DESCRIPTION
The link was going to https://github.com/jenncoop/awesome-phoenix/blob/master/www.phoenixframework.org it now goes to the phoenix website :)
